### PR TITLE
fix: adds wetzlar store buCode (493)

### DIFF
--- a/source/data/buCodes.csv
+++ b/source/data/buCodes.csv
@@ -147,6 +147,7 @@
 482,Anderlecht,be
 488,Renton,us
 483,Arlon,be
+493,Wetzlar,de
 494,Kaarst,de
 519,Sheffield,gb
 522,Goyang,kr

--- a/source/data/stores.json
+++ b/source/data/stores.json
@@ -245,6 +245,11 @@
     "countryCode": "de"
   },
   {
+    "buCode": "493",
+    "name": "Wetzlar",
+    "countryCode": "de"
+  },
+  {
     "buCode": "492",
     "name": "Wuppertal",
     "countryCode": "de"


### PR DESCRIPTION
Adds support for the store in Wetzlar [1]. Should later be merged via a pull-request on origin repo.

[1] https://www.ikea.com/de/de/stores/wetzlar/