### PR TITLE
feat: show forecast data in stock report

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Features
 ================================================================================
 
 - list of 156 IKEA stores worldwide
-- get product stock amount for a product from a whole country or single store in JSON, CSV and CLI-Table format
+- get product stock amount for a product from a whole country or single store in JSON, CSV and CLI-Table format including forecast
 - support for many countries: ae, at, au, ca, ch, cn, cz, de, dk, es, fi, fr, gb
 hk, hr, hu, ie, it, jo, jp, kr, kw, lt, my, nl, no, pl, pt, qa, ro, ru, sa, se, sg, sk, th, tw, us
 - integrate the library into your node project

--- a/README.md
+++ b/README.md
@@ -223,4 +223,4 @@ Other Projects & Articles
 
 * npm package [ikea-stock-checker](https://www.npmjs.com/package/ikea-stock-checker)
 * [API of the Day: Checking IKEA Availability and Warehouse Locations]( https://medium.com/@JoshuaAJung/api-of-the-day-ikea-availability-checks-8678794a9b52) by Joshua Jung
-
+* https://github.com/lovegandhi/ikea-stock-checker

--- a/source/lib/iows2.js
+++ b/source/lib/iows2.js
@@ -92,13 +92,14 @@ class IOWS2 {
   }
 
   /**
-   * @param {object<string, any>} data
+   * @param {object<string, any>} data plain iows endpoint response data object
    * @returns {ProductAvailability} transformed stock information
    */
   static parseAvailabilityFromResponseData(data) {
     const availability = data.StockAvailability;
 
-    // extract forecast data from json
+    // AvailableStockForecastList can contain estimated stock amounts in the
+    // next 4 days.
     const forecastData = availability.AvailableStockForecastList.AvailableStockForecast || [];
     const forecast = forecastData.map(item => ({
       stock: parseInt(item.AvailableStock.$, 10),
@@ -106,6 +107,8 @@ class IOWS2 {
       probability: item.InStockProbabilityCode.$,
     }));
 
+    // RestockDateTime may contain an estimated date when the product gets
+    // restocked. It also can be missing in the response
     let restockDate = null;
     if (availability.RetailItemAvailability.RestockDateTime) {
       restockDate = new Date(availability.RetailItemAvailability.RestockDateTime.$);

--- a/source/lib/iows2.js
+++ b/source/lib/iows2.js
@@ -12,6 +12,16 @@ const stores = require('./stores');
  */
 
 /**
+ * @typedef {object} ProductAvailabilityForecastItem
+ * @property {createdAt} date
+ *   instance of a date for which the estimation is made
+ * @property {number} stock
+ *   estimated number of items in stock on the forecasted date
+ * @property {ProductAvailabilityProbability} probability
+ *   probability of the product beeing in store ("LOW", "MEDIUM" or "HIGH")
+ */
+
+/**
  * @typedef {Object} ProductAvailability
  * @property {Date} createdAt instance of a javascript date of the moment when
  *   the data was created.
@@ -23,6 +33,11 @@ const stores = require('./stores');
  *   ikea store identification number
  * @property {Number} stock
  *   number of items currently in stock
+ * @property {ProductAvailabilityForecastItem[]} [forecast]
+ *   when available a list of items indicating the estimated stock amount in the
+ *   next days
+ * @property {Date} [restockDate]
+ *   Estimated date when the item gets restocked. Can be empty
  */
 
 /**
@@ -87,7 +102,7 @@ class IOWS2 {
     const forecastData = availability.AvailableStockForecastList.AvailableStockForecast || [];
     const forecast = forecastData.map(item => ({
       stock: parseInt(item.AvailableStock.$, 10),
-      createdAt: new Date(item.ValidDateTime.$),
+      date: new Date(item.ValidDateTime.$),
       probability: item.InStockProbabilityCode.$,
     }));
 

--- a/source/lib/reporter/stock-table.js
+++ b/source/lib/reporter/stock-table.js
@@ -65,10 +65,9 @@ module.exports = {
 
         let restockColumn = '';
         if (availability.restockDate) {
-          const daysUntilRestock = diffDays(availability.restockDate, new Date());
-          restockColumn = restockDate.toISOString().substr(0, 10);
+          const daysUntilRestock = Math.floor(diffDays(availability.restockDate, new Date()));
           if (daysUntilRestock > 0) {
-            restockColumn += ' ' + Math.floor(daysUntilRestock) + 'd';
+            restockColumn = `in ${daysUntilRestock}d (${restockDate.toISOString().substr(0, 10)})`;
           }
         }
 

--- a/source/lib/reporter/stock-table.js
+++ b/source/lib/reporter/stock-table.js
@@ -27,6 +27,10 @@ function probabilityColor(val) {
   }
 }
 
+function diffDays(date1, date2) {
+  return (date1.getTime() - date2.getTime()) / 60 / 60 / 24 / 1000;
+}
+
 module.exports = {
   createReport: function(data) {
     let table = new Table({
@@ -39,6 +43,8 @@ module.exports = {
         'store',
         'stock',
         'probability',
+        'restockDate',
+        'forecast',
       ],
       colAligns: [
         null,
@@ -49,20 +55,42 @@ module.exports = {
         null,
         'right',
         'right',
+        null,
       ],
     });
 
     data
-      .map(({ productId, store, availability }) => [
-        availability.createdAt.toISOString(),
-        store.countryCode,
-        countries.getName(store.countryCode, 'en'),
-        productId,
-        store.buCode,
-        store.name,
-        availabilityColor(availability.stock)(availability.stock),
-        probabilityColor(availability.probability)(availability.probability),
-      ])
+      .map(({ productId, store, availability }) => {
+        const { restockDate, createdAt, stock, probability } = availability;
+
+        let restockColumn = '';
+        if (availability.restockDate) {
+          const daysUntilRestock = diffDays(availability.restockDate, new Date());
+          restockColumn = restockDate.toISOString().substr(0, 10);
+          if (daysUntilRestock > 0) {
+            restockColumn += ' ' + Math.floor(daysUntilRestock) + 'd';
+          }
+        }
+
+        const forecast = availability.forecast.map(item => {
+          const shortDate = item.createdAt.toISOString().substr(5, 5);
+          const coloredStock = availabilityColor(item.stock)(item.stock);
+          return `${shortDate}: ${coloredStock}`;
+        }).join(', ');
+
+        return [
+          createdAt.toISOString(),
+          store.countryCode,
+          countries.getName(store.countryCode, 'en'),
+          productId,
+          store.buCode,
+          store.name,
+          availabilityColor(stock)(stock),
+          probabilityColor(probability)(probability),
+          restockColumn,
+          forecast,
+        ]
+      })
       .forEach(row => table.push(row));
 
     return table.toString();

--- a/source/lib/reporter/stock-table.js
+++ b/source/lib/reporter/stock-table.js
@@ -73,7 +73,7 @@ module.exports = {
         }
 
         const forecast = availability.forecast.map(item => {
-          const shortDate = item.createdAt.toISOString().substr(5, 5);
+          const shortDate = item.date.toISOString().substr(5, 5);
           const coloredStock = availabilityColor(item.stock)(item.stock);
           return `${shortDate}: ${coloredStock}`;
         }).join(', ');


### PR DESCRIPTION
The response of the IOWS endpoint also returns estimations/forecast stock amounts and an estimated restock date when a product is out of stock:

```json
{
    "StockAvailability": {
        "RetailItemAvailability": {
            "AvailableStock": {
                "$": "0"
            },
            "AvailableStockType": {
                "$": "STORE"
            },
            "InStockProbabilityCode": {
                "$": "LOW"
            },
            "RestockDateTime": {
                "$": "2020-09-15"
            },
        },
        "AvailableStockForecastList": {
            "AvailableStockForecast": [
                {
                    "AvailableStock": {
                        "$": "0"
                    },
                    "InStockProbabilityCode": {
                        "$": "LOW"
                    },
                    "ValidDateTime": {
                        "$": "2020-09-08"
                    },
                }
            ]
        }
    }
}
```

It looks like there are always estimations for the next 4 days.

This data is now also shown when the "stock" sub-command is used:

```
┌──────────────────────────┬─────────────┬─────────┬──────────┬──────────────────┬──────────┬───────┬─────────────┬────────────────────┬────────────────────────────────────────┐
│ date                     │ countryCode │ country │ product  │ storeId (buCode) │ store    │ stock │ probability │ restockDate        │ forecast                               │
├──────────────────────────┼─────────────┼─────────┼──────────┼──────────────────┼──────────┼───────┼─────────────┼────────────────────┼────────────────────────────────────────┤
│ 2020-09-07T08:45:24.768Z │ de          │ Germany │ 40299687 │ 425              │ Duisburg │     0 │         LOW │ in 7d (2020-09-15) │ 09-08: 0, 09-09: 0, 09-10: 0, 09-11: 0 │
├──────────────────────────┼─────────────┼─────────┼──────────┼──────────────────┼──────────┼───────┼─────────────┼────────────────────┼────────────────────────────────────────┤
│ 2020-09-07T08:45:27.604Z │ de          │ Germany │ 40299687 │ 494              │ Kaarst   │     8 │        HIGH │                    │ 09-08: 6, 09-09: 5, 09-10: 4, 09-11: 3 │
├──────────────────────────┼─────────────┼─────────┼──────────┼──────────────────┼──────────┼───────┼─────────────┼────────────────────┼────────────────────────────────────────┤
│ 2020-09-07T08:45:24.768Z │ de          │ Germany │ 40299687 │ 493              │ Wetzlar  │     2 │      MEDIUM │                    │ 09-08: 2, 09-09: 1, 09-10: 1, 09-11: 1 │
├──────────────────────────┼─────────────┼─────────┼──────────┼──────────────────┼──────────┼───────┼─────────────┼────────────────────┼────────────────────────────────────────┤
│ 2020-09-07T08:45:24.768Z │ de          │ Germany │ 90374274 │ 425              │ Duisburg │     0 │         LOW │                    │ 09-08: 0, 09-09: 0, 09-10: 0, 09-11: 0 │
├──────────────────────────┼─────────────┼─────────┼──────────┼──────────────────┼──────────┼───────┼─────────────┼────────────────────┼────────────────────────────────────────┤
│ 2020-09-07T08:45:24.817Z │ de          │ Germany │ 90374274 │ 494              │ Kaarst   │     0 │         LOW │                    │ 09-08: 0, 09-09: 0, 09-10: 0, 09-11: 0 │
├──────────────────────────┼─────────────┼─────────┼──────────┼──────────────────┼──────────┼───────┼─────────────┼────────────────────┼────────────────────────────────────────┤
│ 2020-09-07T08:45:24.769Z │ de          │ Germany │ 90374274 │ 493              │ Wetzlar  │     0 │         LOW │                    │ 09-08: 0, 09-09: 0, 09-10: 0, 09-11: 0 │
└──────────────────────────┴─────────────┴─────────┴──────────┴──────────────────┴──────────┴───────┴─────────────┴────────────────────┴────────────────────────────────────────┘