### PR TITLE
Migrate to cli-table3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -587,12 +587,14 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+    "cli-table3": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "requires": {
-        "colors": "1.0.3"
+        "colors": "^1.1.2",
+        "object-assign": "^4.1.0",
+        "string-width": "^4.2.0"
       }
     },
     "cliui": {
@@ -620,9 +622,10 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "optional": true
     },
     "commander": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
-    "cli-table": "^0.3.1",
+    "cli-table3": "^0.6.0",
     "commander": "^6.0.0",
     "csv-string": "^4.0.1",
     "debug": "^4.1.1",

--- a/source/lib/reporter/stock-table.js
+++ b/source/lib/reporter/stock-table.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let Table = require('cli-table');
+let Table = require('cli-table3');
 let chalk = require('chalk');
 let countries = require('i18n-iso-countries');
 

--- a/source/lib/reporter/stores-table.js
+++ b/source/lib/reporter/stores-table.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let Table = require('cli-table');
+let Table = require('cli-table3');
 let countries = require('i18n-iso-countries');
 
 module.exports = {


### PR DESCRIPTION
This PR simply replaces `cli-table` with `cli-table3`.

[`cli-table3`](https://github.com/cli-table/cli-table3) has API compatibility with `cli-table` which is unmaintained for a long time.
I believe a lot of projects have already migrated their dependencies to `cli-table3` (see [npm trends](https://www.npmtrends.com/cli-table-vs-cli-table2-vs-cli-table3)).

This change aims to fix a bug in the output when using stores in Asia. The bug is reported a very long time ago, but has been untouched (https://github.com/Automattic/cli-table/pull/67?w=1). 

### `cli-table`
![cli-table](https://user-images.githubusercontent.com/1837005/108811028-cbb1e900-75ef-11eb-9d1d-df27b469e364.png)

### `cli-table3`
![cli-table3](https://user-images.githubusercontent.com/1837005/108811055-dcfaf580-75ef-11eb-960b-c597f1a87760.png)
