### PR TITLE
fix: missing canadian store

### DIFF
--- a/source/data/stores.json
+++ b/source/data/stores.json
@@ -2754,6 +2754,15 @@
     "countryCode": "ca"
   },
   {
+    "buCode": "372",
+    "name": "Vaughn",
+    "coordinates": [
+      79.8334908,
+      43.3281787
+    ],
+    "countryCode": "ca"
+  },
+  {
     "buCode": "249",
     "name": "Winnipeg",
     "coordinates": [


### PR DESCRIPTION
The Vaughn location in Canada was missing. I added it to stores.json. See screenshot for proof of testing.

<img width="1253" alt="Screen Shot 2021-05-10 at 3 25 57 PM" src="https://user-images.githubusercontent.com/14979549/117713753-0fa29c00-b1a4-11eb-9428-377759b481da.png">
