### PR TITLE
fix(iows): throw a IOWS2DeprecationError on deprecation header

### DIFF
--- a/source/cli-stock.js
+++ b/source/cli-stock.js
@@ -122,9 +122,11 @@ Examples:
           if (err instanceof errors.IOWS2ParseError) {
             return { stock: 0, probability: 'PARSE_ERROR', createdAt: new Date() };
           }
-          // when product could not be found return an empty availability
-          if (err.response && err.response.status === 404 && promises.length > 1) {
+          if (err instanceof errors.IOWS2NotFoundError) {
             return { stock: 0, probability: 'NOT_FOUND', createdAt: new Date() };
+          }
+          if (err instanceof errors.IOWS2DeprecatedError) {
+            return { stock: 0, probability: 'DEPRECATED', createdAt: new Date() };
           }
           throw err;
         })

--- a/source/lib/iows2Errors.js
+++ b/source/lib/iows2Errors.js
@@ -10,7 +10,7 @@ class IOWS2ParseError extends IOWS2Error{
 
 class IOWS2ResponseError extends IOWS2Error {
   /**
-   * @param {import('axios').AxiosError} error error message
+   * @param {import('axios').AxiosError} error Axios Error object
    */
   constructor(error) {
     super(error.message);
@@ -18,8 +18,13 @@ class IOWS2ResponseError extends IOWS2Error {
   }
 }
 
+class IOWS2DeprecatedError extends IOWS2ResponseError {}
+class IOWS2NotFoundError extends IOWS2ResponseError {}
+
 module.exports = {
+  IOWS2DeprecatedError,
   IOWS2Error,
+  IOWS2NotFoundError,
   IOWS2ParseError,
   IOWS2ResponseError,
-}
+};


### PR DESCRIPTION
Starting today I’ve noticed that the IOWS API returns the following headers for some countries:

```
{
  'x-backside-transport': 'FAIL FAIL,FAIL FAIL,FAIL FAIL',
  'content-type': 'application/json',
  deprecation: 'version="1", date="Sat, 31 Dec 2022 23:59:59 GMT"',
  warning: 'IOWSStockAvailabilityService.GetStockAvailability.v1 API is now deprecated.',
  link: 'alternate="Customer Item Availability. Enquire via slack #rrm-cia"',
  'x-global-transaction-id': 'a345495061bc8cb3084964a1',
  'unique-rq-id': '1639746739-27b3ad3b',
  'content-length': '0',
  date: 'Fri, 17 Dec 2021 13:12:19 GMT',
  connection: 'close',
  'x-content-type-options': 'nosniff',
  'strict-transport-security': 'max-age=31536000',
  server: 'IITP Server',
}
```

Unfortunatly the API tells the client that it will get deprecated on 31.12.2022 but doesn’t send any results anymore. 

I changed the code to throw a `IOWS2Deprecation` error in this cases which will show up as `DEPRECATED` in the table.