### PR TITLE
fix(stores): geolocation of karlsruhe germany

### DIFF
--- a/source/data/stores.json
+++ b/source/data/stores.json
@@ -255,8 +255,8 @@
     "buCode": "551",
     "name": "Karlsruhe",
     "coordinates": [
-      38.925,
-      45.0125
+      8.4420776,
+      49.0048648
     ],
     "countryCode": "de"
   },


### PR DESCRIPTION
closes #88 