### PR TITLE
fix(iows): propagate timeout errors

### DIFF
--- a/source/cli-stock.js
+++ b/source/cli-stock.js
@@ -129,6 +129,9 @@ Examples:
           if (err instanceof errors.IOWS2DeprecatedError) {
             return { stock: 0, probability: 'DEPRECATED', createdAt: new Date() };
           }
+          if (err.code === 'ECONNABORTED') {
+            return { stock: 0, probability: 'TIMEOUT', createdAt: new Date() };
+          }
           throw err;
         })
         .then((availability) => ({

--- a/source/lib/iows2.js
+++ b/source/lib/iows2.js
@@ -99,7 +99,7 @@ class IOWS2 {
     try {
       response = await this.api.get(url, options);
     } catch (error) {
-      if (error.request) {
+      if (error.request.res) {
         // 20211217 some of the country endpoints started to reply with a
         // deprecation and warning header stating that the IOWS2 API is
         // going to be deprecated.
@@ -229,7 +229,7 @@ class IOWS2 {
     const url = this.buildUrl(this.baseUrl, this.countryCode, this.languageCode, buCode, productId, productType);
     return this.fetch(url)
       .catch(err => {
-        if (err.request.res) {
+        if (err.request?.res) {
           err.message =
             `Unable to receive product ${productId} availability for store ` +
             `${buCode} status code: ${err.request.res.statusCode} ${err.request.res.statusText} ` +

--- a/source/lib/iows2.test.js
+++ b/source/lib/iows2.test.js
@@ -254,6 +254,18 @@ describe('IOWS2', () => {
         });
     });
 
+    it('propagates a timeout error when the api is not responding', () => {
+      const scope = nock(URL).get(/.+/)
+        .delayConnection(50)
+        .reply(200);
+      return iows.fetch(URL, {timeout: 10}) // reduce timeout to keep test duration low
+        .catch(err => {
+          expect(err).to.be.instanceof(errors.IOWS2ResponseError);
+          expect(err.code).to.equal('ECONNABORTED');
+          scope.isDone();
+        });
+    });
+
     it('sends the correct header and request data', () => {
       const scope = nock(URL, {
         reqheaders: {


### PR DESCRIPTION
Some of my requests got me _ECONNABORTED timeout of 5000ms exceeded_ errors, though the error was not propagated. It gave _Cannot read properties of undefined (reading 'headers')_ errors.
With these changes, the error is properly shown.