### PR TITLE
fix(stores): adds Jurong store in Singapore

### DIFF
--- a/source/data/buCodes.csv
+++ b/source/data/buCodes.csv
@@ -1,7 +1,9 @@
 005,Aalborg,dk
 006,Springvale,au
 018,Avignon,fr
+022,Tampines,sg
 038,Dublin,ie
+045,Alexandra,sg
 051,Hénin-Beaumont,fr
 060,Brest,fr
 063,München-Eching,de
@@ -163,6 +165,7 @@
 557,Adelaid,au
 567,Greenwich,gb
 645,Rivoli,fr
+650,Jurong,sg
 917,St. Gallen SG,ch
 918,Vernier GE,ch
 919,Logan,au

--- a/source/data/stores.json
+++ b/source/data/stores.json
@@ -2114,11 +2114,20 @@
   {
     "buCode": "022",
     "name": "Tampines",
-    "countryCode": "sg",
     "coordinates": [
       103.936040000,
       1.371100000
-    ]
+    ],
+    "countryCode": "sg"
+  },
+  {
+    "buCode": "650",
+    "name": "Jurong",
+    "coordinates": [
+      103.9325,
+      1.3741
+    ],
+    "countryCode": "sg"
   },
   {
     "buCode": "209",


### PR DESCRIPTION
1. Added Jurong(sg) store to stores.json
2. Added 3 sg stores info buCodes.csv

By the way, I also found that there are some slight differences between the coordinates of some shops and official website. Can we automatically crawl and update these contents(coordinates and new store info) from official website?

Infomation source: https://www.ikea.com/sg/en/meta-data/navigation/stores-detailed.json