### PR TITLE
feat(stock): add restockDate for Ingka API

### DIFF
--- a/source/lib/ingka.js
+++ b/source/lib/ingka.js
@@ -17,6 +17,8 @@ const errors = require('./ingkaErrors');
  * @property {import('./stores').Store} store
  * @property {number} stock
  *   number of items currently in stock
+ * @property {Date} [restockDate]
+ *   Estimated date when the item gets restocked. Can be empty
  */
 
 // clientids taken from IKEA.tld websites
@@ -63,7 +65,8 @@ class IngkaApi {
           buCode: item.classUnitKey.classUnitCode,
           productId: item.itemKey.itemNo,
           stock: 0,
-          store: stores.findOneById(item.classUnitKey.classUnitCode)
+          store: stores.findOneById(item.classUnitKey.classUnitCode),
+          restockDate: null,
         };
 
         const cashNCarry = (item.availableStocks || [])
@@ -77,6 +80,9 @@ class IngkaApi {
           ));
           if (probability) {
             ret.probability = probability.communication.messageType;
+          }
+          if(cashNCarry.restocks) {
+            ret.restockDate = new Date(cashNCarry.restocks[0].earliestDate);
           }
         }
 

--- a/source/lib/reporter/stock-table.js
+++ b/source/lib/reporter/stock-table.js
@@ -20,6 +20,10 @@ function availabilityColor(val) {
   }
 }
 
+function diffDays(date1, date2) {
+  return (date1.getTime() - date2.getTime()) / 60 / 60 / 24 / 1000;
+}
+
 /**
  * Returns a function which when applied on a string colors the string in cli
  *
@@ -53,6 +57,7 @@ module.exports = {
         'store',
         'stock',
         'probability',
+        'restockDate',
       ],
       colAligns: [
         null,
@@ -62,12 +67,21 @@ module.exports = {
         null,
         null,
         'right',
+        'right',
       ],
     });
 
     data
       .map(({ productId, store, availability }) => {
-        const { createdAt, stock, probability } = availability;
+        const { restockDate, createdAt, stock, probability } = availability;
+
+        let restockColumn = '';
+        if (restockDate) {
+          const daysUntilRestock = Math.floor(diffDays(restockDate, new Date()));
+          if (daysUntilRestock > 0) {
+            restockColumn = `in ${daysUntilRestock}d (${restockDate.toISOString().substr(0, 10)})`;
+          }
+        }
 
         return [
           createdAt.toISOString(),
@@ -78,6 +92,7 @@ module.exports = {
           store.name,
           availabilityColor(stock)(stock),
           probabilityColor(probability)(probability),
+          restockColumn,
         ]
       })
       .forEach(row => table.push(row));


### PR DESCRIPTION
<!-- make sure the title of the PR follows the angular commit guidelines as it will appear in the changelog -->

# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request, and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem
With the change from Iows2 to Ingka API in the `alpha` branch, the `restockDate` attribute got lost.
<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution
The Ingka API response includes restock deliveries.
```json
{
    "type": "DELIVERY",
    "quantity": 72,
    "earliestDate": "2022-11-02",
    "latestDate": "2022-11-09",
    "updateDateTime": "2022-10-28T04:12:36.002Z",
    "reliability": "HIGH"
}
```
As I wanted to keep the data type as close to the old Iows2 solution as possible, I stripped down the response to just the `earliestDate` of the first delivery.
```js
cashNCarry.restocks[0].earliestDate
```
If we want to give more details to the outer world, it would be an option to include the full array of restocks. That's up for discussion.

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It is ok if you want to show us the code to discuss before doing the extra work, and you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->
```
┌──────────────────────────┬─────────────┬─────────┬──────────┬──────────────────┬──────────┬───────┬──────────────┬────────────────────┐
│ date                     │ countryCode │ country │ product  │ storeId (buCode) │ store    │ stock │  probability │ restockDate        │
├──────────────────────────┼─────────────┼─────────┼──────────┼──────────────────┼──────────┼───────┼──────────────┼────────────────────┤
│ 2022-10-28T11:47:53.246Z │ de          │ Germany │ 60505511 │ 124              │ Würzburg │     0 │ OUT_OF_STOCK │ in 7d (2022-11-05) │
└──────────────────────────┴─────────────┴─────────┴──────────┴──────────────────┴──────────┴───────┴──────────────┴────────────────────┘
```