### PR TITLE
fix(stores): add fi, gb, ee, lv stores and remove closed gb store

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Features
 
 - list of 395 IKEA stores worldwide
 - get product stock amount for a whole country or single store in JSON, CSV and CLI-Table format including forecast (when available)
-- support for many countries: at, au, be, ca, ch, cn, cz, de, dk, es, fi, fr, gb, hk, hr, hu, ie, it, jo, jp, kr, kw, lt, my, nl, no, pl, pt, qa, ro, ru, sa, se, sg, sk, th, tw, us
+- support for many countries: at, au, be, ca, ch, cn, cz, de, dk, ee, es, fi, fr, gb, hk, hr, hu, ie, it, jo, jp, kr, kw, lt, lv, my, nl, no, pl, pt, qa, ro, ru, sa, se, sg, sk, th, tw, us
 - integrate/use the library into your node project
 
 Command Line

--- a/source/data/buCodes.csv
+++ b/source/data/buCodes.csv
@@ -79,7 +79,6 @@
 240,Paris Est Villiers sur Marne,fr
 242,Toulouse,fr
 245,Hamburg-Altona,de
-255,Tottenham,gb
 260,Metz,fr
 261,Leeds,gb
 262,Lakeside,gb

--- a/source/data/buCodes.csv
+++ b/source/data/buCodes.csv
@@ -168,6 +168,7 @@
 567,Greenwich,gb
 642,Hammersmith,gb
 645,Rivoli,fr
+648,Tallinn,ee
 650,Jurong,sg
 917,St. Gallen SG,ch
 918,Vernier GE,ch

--- a/source/data/buCodes.csv
+++ b/source/data/buCodes.csv
@@ -62,6 +62,7 @@
 188,Warszawa / Janki,pl
 198,Reims,fr
 199,Caen Fleury-sur-Orne,fr
+202,Espoo,fi
 203,Gdańsk,pl
 204,Kraków,pl
 205,Poznań,pl
@@ -100,6 +101,7 @@
 292,Pratteln BL,ch
 294,Wrocław,pl
 298,Aarhus,dk
+301,Raisio,fi
 306,Katowice,pl
 307,Warszawa / Targówek,pl
 309,Ostrava,cz

--- a/source/data/buCodes.csv
+++ b/source/data/buCodes.csv
@@ -159,6 +159,7 @@
 488,Renton,us
 493,Wetzlar,de
 494,Kaarst,de
+516,Riga,lv
 519,Sheffield,gb
 522,Goyang,kr
 548,Exeter,gb

--- a/source/data/buCodes.csv
+++ b/source/data/buCodes.csv
@@ -163,6 +163,7 @@
 556,Perth,au
 557,Adelaid,au
 567,Greenwich,gb
+642,Hammersmith,gb
 645,Rivoli,fr
 650,Jurong,sg
 917,St. Gallen SG,ch

--- a/source/data/stores.json
+++ b/source/data/stores.json
@@ -1433,6 +1433,11 @@
     "countryCode": "ee"
   },
   {
+    "buCode": "516",
+    "name": "Riga",
+    "countryCode": "lv"
+  },
+  {
     "buCode": "415",
     "name": "Amersfoort",
     "coordinates": [

--- a/source/data/stores.json
+++ b/source/data/stores.json
@@ -1053,6 +1053,24 @@
     "countryCode": "fi"
   },
   {
+    "buCode": "202",
+    "name": "Espoo",
+    "coordinates": [
+      24.6627,
+      60.2177
+    ],
+    "countryCode": "fi"
+  },
+  {
+    "buCode": "301",
+    "name": "Raisio",
+    "coordinates": [
+      22.2277,
+      60.4943
+    ],
+    "countryCode": "fi"
+  },
+  {
     "buCode": "062",
     "name": "Causeway Bay",
     "coordinates": [

--- a/source/data/stores.json
+++ b/source/data/stores.json
@@ -3308,6 +3308,15 @@
     "countryCode": "gb"
   },
   {
+    "buCode": "642",
+    "name": "Hammersmith",
+    "coordinates": [
+      -0.2403,
+      51.4935
+    ],
+    "countryCode": "gb"
+  },
+  {
     "buCode": "482",
     "name": "Anderlecht",
     "coordinates": [

--- a/source/data/stores.json
+++ b/source/data/stores.json
@@ -1428,6 +1428,11 @@
     "countryCode": "lt"
   },
   {
+    "buCode": "648",
+    "name": "Tallinn",
+    "countryCode": "ee"
+  },
+  {
     "buCode": "415",
     "name": "Amersfoort",
     "coordinates": [

--- a/source/data/stores.json
+++ b/source/data/stores.json
@@ -3290,15 +3290,6 @@
     "countryCode": "gb"
   },
   {
-    "buCode": "255",
-    "name": "Tottenham",
-    "coordinates": [
-      -0.047207,
-      51.608716
-    ],
-    "countryCode": "gb"
-  },
-  {
     "buCode": "140",
     "name": "Warrington",
     "coordinates": [


### PR DESCRIPTION
# Pull Request
## Problem
Some `fi`, `ee`, `lv` and `gb` stores were missing
## Solution
Add new stores, remove closed store
